### PR TITLE
Use structured config for lazy.nvim

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,29 +1,7 @@
 vim.g.base46_cache = vim.fn.stdpath "data" .. "/base46/"
 vim.g.mapleader = " "
 
--- bootstrap lazy and all plugins
-local lazypath = vim.fn.stdpath "data" .. "/lazy/lazy.nvim"
-
-if not vim.uv.fs_stat(lazypath) then
-  local repo = "https://github.com/folke/lazy.nvim.git"
-  vim.fn.system { "git", "clone", "--filter=blob:none", repo, "--branch=stable", lazypath }
-end
-
-vim.opt.rtp:prepend(lazypath)
-
-local lazy_config = require "configs.lazy"
-
--- load plugins
-require("lazy").setup({
-  {
-    "NvChad/NvChad",
-    lazy = false,
-    branch = "v2.5",
-    import = "nvchad.plugins",
-  },
-
-  { import = "plugins" },
-}, lazy_config)
+require "configs.lazy"
 
 -- load theme
 dofile(vim.g.base46_cache .. "defaults")

--- a/lua/configs/lazy.lua
+++ b/lua/configs/lazy.lua
@@ -1,4 +1,15 @@
-return {
+-- bootstrap lazy and all plugins
+local lazypath = vim.fn.stdpath "data" .. "/lazy/lazy.nvim"
+
+if not vim.uv.fs_stat(lazypath) then
+  local repo = "https://github.com/folke/lazy.nvim.git"
+  vim.fn.system { "git", "clone", "--filter=blob:none", repo, "--branch=stable", lazypath }
+end
+
+vim.opt.rtp:prepend(lazypath)
+
+-- nvchad lazy_config
+local lazy_config = {
   defaults = { lazy = true },
   install = { colorscheme = { "nvchad" } },
 
@@ -45,3 +56,15 @@ return {
     },
   },
 }
+
+-- load plugins
+require("lazy").setup({
+  {
+    "NvChad/NvChad",
+    lazy = false,
+    branch = "v2.5",
+    import = "nvchad.plugins",
+  },
+
+  { import = "plugins" },
+}, lazy_config)


### PR DESCRIPTION
Tested by deleting nvchad config then cloning this branch and then opening nvim it was observed that all the plugins got installed
Output from `:checkhealth lazy`
<img width="772" alt="image" src="https://github.com/user-attachments/assets/58c1e7f4-a20b-4e41-ab21-051c6a752588" />
